### PR TITLE
Remove unnecessary fields from the JSON template

### DIFF
--- a/expected.json
+++ b/expected.json
@@ -135,19 +135,13 @@
       "unit":"%"
     },
     {
-      "nutrient":"Argile",
-      "value":"",
-      "unit":""
+      "nutrient":"Argile"
     },
     {
-      "nutrient":"Sable",
-      "value":"",
-      "unit":""
+      "nutrient":"Sable"
     },
     {
-      "nutrient":"Perlite",
-      "value":"",
-      "unit":""
+      "nutrient":"Perlite"
     }
   ],
   "specifications_fr":[


### PR DESCRIPTION
Clean up expected.json from unnecessary fields.

Should help with some of the tests on the [backend](https://github.com/ai-cfia/fertiscan-backend/pulls)/datastore.