### PR TITLE
Issue #19: Use the pydantic schema inside the prompt

### DIFF
--- a/pipeline/gpt.py
+++ b/pipeline/gpt.py
@@ -3,44 +3,14 @@ from dspy import Prediction
 import dspy.adapters
 import dspy.utils
 
+from pipeline.inspection import FertilizerInspection
+
 MODELS_WITH_RESPONSE_FORMAT = [
     "ailab-llm",
     "ailab-llm-gpt-4o"
 ]  # List of models that support the response_format option
 
-SPECIFICATION = """
-Keys:
-"company_name"
-"company_address"
-"company_website"
-"company_phone_number"
-"manufacturer_name"
-"manufacturer_address"
-"manufacturer_website"
-"manufacturer_phone_number"
-"fertiliser_name"
-"registration_number" (a series of letters and numbers)
-"lot_number"
-"weight" (array of objects with "value", and "unit")
-"density" (an object with "value", and "unit")
-"volume" (an object with "value", and "unit")
-"npk" (format: "number-number-number") **important
-"guaranteed_analysis" (array of objects with "nutrient", "value", and "unit") **important
-"warranty"
-"cautions_en"  (array of strings)
-"instructions_en" (array of strings)
-"micronutrients_en" (array of objects with "nutrient", "value", and "unit")
-"ingredients_en" (array of objects with "nutrient", "value", and "unit")
-"specifications_en" (array of objects with "humidity", "ph", and "solubility")
-"first_aid_en"  (array of strings)
-"cautions_fr" (array of strings)
-"instructions_fr" (array of strings)
-"micronutrients_fr" (array of objects with "nutrient", "value", and "unit")
-"ingredients_fr" (array of objects with "nutrient", "value", and "unit")
-"specifications_fr" (array of objects with "humidity", "ph", and "solubility")
-"first_aid_fr" (array of strings)
-
-Requirements:
+REQUIREMENTS = """
 The content of keys with the suffix _en must be in English.
 The content of keys with the suffix _fr must be in French.
 Translation of the text is prohibited.
@@ -56,7 +26,8 @@ class ProduceLabelForm(dspy.Signature):
     """
     
     text = dspy.InputField(desc="The text of the fertilizer label extracted using OCR.")
-    specification = dspy.InputField(desc="The specification containing the fields to highlight and their requirements.")
+    json_schema = dspy.InputField(desc="The JSON schema of the object to be returned.")
+    requirements = dspy.InputField(desc="The instructions and guidelines to follow.")
     inspection = dspy.OutputField(desc="Only a complete JSON.")
 
 class GPT:
@@ -87,9 +58,10 @@ class GPT:
             response_format=response_format,
         )
 
-    def create_inspection(self, prompt) -> Prediction:
+    def create_inspection(self, text) -> Prediction:
         with dspy.context(lm=self.dspy_client, experimental=True):
+            json_schema = FertilizerInspection.model_json_schema()
             signature = dspy.ChainOfThought(ProduceLabelForm)
-            prediction = signature(specification=SPECIFICATION, text=prompt)
+            prediction = signature(text=text, json_schema=json_schema, requirements=REQUIREMENTS)
 
         return prediction

--- a/pipeline/gpt.py
+++ b/pipeline/gpt.py
@@ -12,7 +12,7 @@ SUPPORTED_MODELS = {
         "response_format": { "type": "json_object" },
     },
     "gpt-4o": {
-        "max_token": 4096,
+        "max_token": None,
         "api_version": "2024-02-15-preview",
         "response_format": { "type": "json_object" },
     }


### PR DESCRIPTION
Currently it's not possible to use **json_schema** as the `response_format`.

In the meantime, I added an additional input field to the DSPy prompt that accepts a JSON schema. Namely the one from pydantic. Since we can't guarantee at this level that the output will always fit the schema, more testing is necessary.

Related to #19 