### PR TITLE
Issue#42: check if the registration_number format is correct

### DIFF
--- a/pipeline/inspection.py
+++ b/pipeline/inspection.py
@@ -124,6 +124,14 @@ class FertilizerInspection(BaseModel):
         if v is None:
             v = []
         return v
+    
+    @field_validator("registration_number", mode="before")
+    def check_registration_number_format(cls, v):
+        if v is not None:
+            pattern = r'^\d{7}[A-Z]$'
+            if re.match(pattern, v):
+                return v
+        return None
 
     class Config:
         populate_by_name = True

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -241,6 +241,35 @@ class TestFertilizerInspectionListFields(unittest.TestCase):
         self.assertEqual(inspection.ingredients_en, [])
         self.assertEqual(inspection.ingredients_fr, [])
         self.assertEqual(inspection.weight, [])
+        
+class TestFertilizerInspectionRegistrationNumber(unittest.TestCase):
+    def test_registration_number_with_less_digits(self):
+        instance = FertilizerInspection(registration_number="1234")
+        self.assertIsNone(instance.registration_number)
+
+    def test_registration_number_less_than_seven_digits(self):
+        instance = FertilizerInspection(registration_number="12345A")
+        self.assertIsNone(instance.registration_number)
+
+    def test_registration_number_seven_digits_no_letter(self):
+        instance = FertilizerInspection(registration_number="1234567")
+        self.assertIsNone(instance.registration_number)
+
+    def test_registration_number_seven_digits_with_lowercase_letter(self):
+        instance = FertilizerInspection(registration_number="1234567a")
+        self.assertIsNone(instance.registration_number)
+
+    def test_registration_number_correct_format(self):
+        instance = FertilizerInspection(registration_number="1234567A")
+        self.assertEqual(instance.registration_number, "1234567A")
+
+    def test_registration_number_extra_characters(self):
+        instance = FertilizerInspection(registration_number="12345678B")
+        self.assertIsNone(instance.registration_number)
+
+    def test_registration_number_mixed_format(self):
+        instance = FertilizerInspection(registration_number="12A34567B")
+        self.assertIsNone(instance.registration_number)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Issue#42: Check if the registration_number format in FertilizerInspection is correct. Otherwise it will be None.