### PR TITLE
30 registration number

### DIFF
--- a/expected.json
+++ b/expected.json
@@ -8,7 +8,12 @@
   "manufacturer_website": "https://www.agrisupply.com",
   "manufacturer_phone_number": "987-654-3210",
   "fertiliser_name": "GreenGrow Fertilizer 20-20-20",
-  "registration_number": "2018007A",
+  "registration_number": [
+    {
+      "identifier": "2018007A",
+      "type": "fertilizer_product"
+    }
+  ],
   "lot_number": "LOT20240901",
   "weight": [
     {

--- a/pipeline/inspection.py
+++ b/pipeline/inspection.py
@@ -1,4 +1,5 @@
 import re
+from enum import Enum
 from typing import Annotated, List, Optional
 
 import phonenumbers
@@ -54,6 +55,23 @@ class Value(BaseModel):
             return extract_first_number(v)
         return None
 
+# class syntax
+
+class RegistrationNumberType(Enum):
+    INGREDIENT = "ingredient"
+    FERTILIZER = "fertilizer"
+
+class RegistrationNumber(BaseModel):
+    number: str
+    type: Optional[RegistrationNumberType] = None
+
+    @field_validator("number", mode="before")
+    def check_registration_number_format(cls, v):
+        if v is not None:
+            pattern = r"^\d{7}[A-Z]$"
+            if re.match(pattern, v):
+                return v
+        return None
 
 class GuaranteedAnalysis(BaseModel):
     title: Optional[str] = None
@@ -115,7 +133,7 @@ class FertilizerInspection(BaseModel):
         None, description="The manufacturer's primary phone number. Return only one."
     )
     fertiliser_name: Optional[str] = None
-    registration_number: Optional[str] = None
+    registration_number: List[RegistrationNumber] = []
     lot_number: Optional[str] = None
     weight: List[Value] = []
     density: Optional[Value] = None
@@ -153,14 +171,6 @@ class FertilizerInspection(BaseModel):
         if v is None:
             v = []
         return v
-
-    @field_validator("registration_number", mode="before")
-    def check_registration_number_format(cls, v):
-        if v is not None:
-            pattern = r"^\d{7}[A-Z]$"
-            if re.match(pattern, v):
-                return v
-        return None
 
     @field_validator("company_phone_number", "manufacturer_phone_number", mode="before")
     def check_phone_number_format(cls, v):

--- a/pipeline/inspection.py
+++ b/pipeline/inspection.py
@@ -57,15 +57,21 @@ class Value(BaseModel):
 
 # class syntax
 
-class RegistrationNumberType(Enum):
-    INGREDIENT = "ingredient"
-    FERTILIZER = "fertilizer"
+class RegistrationNumberType(str, Enum):
+    """
+    Represents the type of registration number for fertilizers.
+
+    - INGREDIENT: Refers to a registration number associated with a specific ingredient in the ingredient list of a fertilizer.
+    - FERTILIZER: Refers to the unique registration number assigned to the fertilizer product itself.
+    """
+    INGREDIENT = "ingredient_component"
+    FERTILIZER = "fertilizer_product"
 
 class RegistrationNumber(BaseModel):
-    number: str
+    identifier: str = Field(..., description="A string composed of 7-digit number followed by an uppercase letter.")
     type: Optional[RegistrationNumberType] = None
 
-    @field_validator("number", mode="before")
+    @field_validator("identifier", mode="before")
     def check_registration_number_format(cls, v):
         if v is not None:
             pattern = r"^\d{7}[A-Z]$"
@@ -164,11 +170,12 @@ class FertilizerInspection(BaseModel):
         "instructions_fr",
         "ingredients_en",
         "ingredients_fr",
+        "registration_number",
         "weight",
         mode="before",
     )
     def replace_none_with_empty_list(cls, v):
-        if v is None:
+        if v is None or v == 0:
             v = []
         return v
 

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -3,6 +3,8 @@ import unittest
 from pipeline.inspection import (
     FertilizerInspection,
     GuaranteedAnalysis,
+    RegistrationNumber,
+    RegistrationNumberType,
     NutrientValue,
     Specification,
     Value,
@@ -206,6 +208,73 @@ class TestNPKValidation(unittest.TestCase):
                     inspection.npk, f"Expected None for npk with input {npk}"
                 )
 
+class TestRegistrationNumber(unittest.TestCase):
+    def setUp(self):
+        self.valid_registration_number_data = [
+            "1234567A",
+            "1234567B",
+            "1234567C",
+            "1234567D",
+            "1234567E",
+            "1234567F",
+            "1234567G",
+            "1234567H",
+            "1234567I",
+            "1234567J",
+            "1234567K",
+            "1234567L",
+            "1234567M",
+            "1234567N",
+            "1234567O",
+            "1234567P",
+            "1234567Q",
+            "1234567R",
+            "1234567S",
+            "1234567T",
+            "1234567U",
+            "1234567V",
+            "1234567W",
+            "1234567X",
+            "1234567Y",
+            "1234567Z",
+        ]
+
+        self.invalid_registration_number_data = [
+            "1234567",
+            "1234567AA",
+            "1234567A1",
+            "1234567A ",
+            "1234567 A",
+            "1234567A-",
+            "1234567A.",
+            "1234567A,",
+        ]
+
+        self.invalid_registration_type_data = [
+            "FERTILIZER",
+            "INGREDIENT",
+            "PRODUCT",
+            "COMPONENT",
+        ]
+
+    def test_valid_registration_number(self):
+        for registration_number in self.valid_registration_number_data:
+            with self.subTest(registration_number=registration_number):
+                registration = RegistrationNumber(identifier=registration_number)
+                self.assertEqual(registration.identifier, registration_number)
+            
+    def test_invalid_registration_number(self):
+        for registration_number in self.invalid_registration_number_data:
+            with self.subTest(registration_number=registration_number):
+                with self.assertRaises(ValueError):
+                    RegistrationNumber(identifier=registration_number, type=RegistrationNumberType.FERTILIZER)
+
+    def test_invalid_registration_type(self):
+        for registration_type in self.invalid_registration_type_data:
+            with self.subTest(registration_type=registration_type):
+                with self.assertRaises(ValueError):
+                    RegistrationNumber(identifier="1234567A", type=registration_type)
+    
 
 class TestGuaranteedAnalysis(unittest.TestCase):
     def setUp(self):
@@ -246,7 +315,12 @@ class TestFertilizerInspectionListFields(unittest.TestCase):
             "manufacturer_website": "https://manufacturer.com",
             "manufacturer_phone_number": "098-765-4321",
             "fertiliser_name": "Test Fertilizer",
-            "registration_number": "ABC123",
+            "registration_number": [
+                {
+                    "identifier": "1234567A",
+                    "type": RegistrationNumberType.FERTILIZER,
+                }
+            ],
             "lot_number": "LOT987",
             "npk": "10-5-20",
             "guaranteed_analysis_en": None,
@@ -269,37 +343,6 @@ class TestFertilizerInspectionListFields(unittest.TestCase):
         self.assertEqual(inspection.ingredients_en, [])
         self.assertEqual(inspection.ingredients_fr, [])
         self.assertEqual(inspection.weight, [])
-
-
-class TestFertilizerInspectionRegistrationNumber(unittest.TestCase):
-    def test_registration_number_with_less_digits(self):
-        instance = FertilizerInspection(registration_number="1234")
-        self.assertIsNone(instance.registration_number)
-
-    def test_registration_number_less_than_seven_digits(self):
-        instance = FertilizerInspection(registration_number="12345A")
-        self.assertIsNone(instance.registration_number)
-
-    def test_registration_number_seven_digits_no_letter(self):
-        instance = FertilizerInspection(registration_number="1234567")
-        self.assertIsNone(instance.registration_number)
-
-    def test_registration_number_seven_digits_with_lowercase_letter(self):
-        instance = FertilizerInspection(registration_number="1234567a")
-        self.assertIsNone(instance.registration_number)
-
-    def test_registration_number_correct_format(self):
-        instance = FertilizerInspection(registration_number="1234567A")
-        self.assertEqual(instance.registration_number, "1234567A")
-
-    def test_registration_number_extra_characters(self):
-        instance = FertilizerInspection(registration_number="12345678B")
-        self.assertIsNone(instance.registration_number)
-
-    def test_registration_number_mixed_format(self):
-        instance = FertilizerInspection(registration_number="12A34567B")
-        self.assertIsNone(instance.registration_number)
-
 
 class TestFertilizerInspectionPhoneNumberFormat(unittest.TestCase):
     def test_valid_phone_number_with_country_code(self):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -210,7 +210,7 @@ class TestInspectionAnnotatedFields(unittest.TestCase):
 
         # Assertions for website fields
         self.assertEqual(
-            inspection.company_website, "www.advancednutrients.com/growersupport"
+            inspection.man, "www.advancednutrients.com/growersupport"
         )
 
 


### PR DESCRIPTION
The schema implemented :

```json
{
  "registration_number":[
    {
      "identifier":"reg number 1",
      "type":"Ingredient or Fertilizer/self"
    }
  ]
},

```

Closes #30 