### PR TITLE
Issue #66 : Use in-memory object with the LabelStorage

### DIFF
--- a/pipeline/label.py
+++ b/pipeline/label.py
@@ -1,25 +1,26 @@
-import os
 from PIL import Image
 from io import BytesIO
 from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import letter
+from reportlab.lib.utils import ImageReader
 
 class LabelStorage:
     def __init__(self):
         self.images = []
 
-    def add_image(self, image: str):
-        if not os.path.exists(image):
-            raise FileNotFoundError(f"The file {image} does not exist.")
-        self.images.append(image)
+    def add_image(self, image_bytes: bytes):
+        try:
+            image = BytesIO(image_bytes)
+            self.images.append(image)
+        except Exception as e:
+            raise ValueError(f"Invalid image data: {e}")
 
     def _create_composite_image(self) -> Image:
         if not self.images:
             raise ValueError("No images to merge.")
 
-        # Open images and get their dimensions
-        opened_images = [Image.open(image_path) for image_path in self.images]
-        widths, heights = zip(*(img.size for img in opened_images))
+        # Get dimensions of images
+        widths, heights = zip(*(img.size for img in self.images))
 
         total_height = sum(heights)
         max_width = max(widths)
@@ -28,7 +29,7 @@ class LabelStorage:
         composite_image = Image.new('RGB', (max_width, total_height))
 
         y_offset = 0
-        for img in opened_images:
+        for img in self.images:
             composite_image.paste(img, (0, y_offset))
             y_offset += img.height
 
@@ -39,9 +40,14 @@ class LabelStorage:
         c = canvas.Canvas(pdf_buffer, pagesize=letter)
 
         for image in self.images:
+            # Convert PIL image to bytes
+            img_buffer = ImageReader(image)
+            # image.save(img_buffer, format='PNG')
+            # img_buffer.seek(0)
+
             # Add image to the PDF page
-            c.drawImage(image=image, x=0, y=0, width=letter[0], height=letter[1])
-            c.showPage()  # End the current page and start a new one
+            c.drawImage(image=img_buffer, x=0, y=0, width=letter[0], height=letter[1])
+            # c.showPage()  # End the current page and start a new one
 
         c.save()
         pdf_buffer.seek(0)
@@ -49,9 +55,6 @@ class LabelStorage:
         return pdf_buffer
     
     def clear(self):
-        for image_path in self.images:
-            os.remove(image_path)
-
         self.images = []
 
     def get_document(self, format='pdf') -> bytes:

--- a/pipeline/label.py
+++ b/pipeline/label.py
@@ -10,7 +10,7 @@ class LabelStorage:
 
     def add_image(self, image_bytes: bytes):
         try:
-            image = BytesIO(image_bytes)
+            image = Image.open(BytesIO(image_bytes))
             self.images.append(image)
         except Exception as e:
             raise ValueError(f"Invalid image data: {e}")
@@ -42,12 +42,10 @@ class LabelStorage:
         for image in self.images:
             # Convert PIL image to bytes
             img_buffer = ImageReader(image)
-            # image.save(img_buffer, format='PNG')
-            # img_buffer.seek(0)
 
             # Add image to the PDF page
             c.drawImage(image=img_buffer, x=0, y=0, width=letter[0], height=letter[1])
-            # c.showPage()  # End the current page and start a new one
+            c.showPage()  # End the current page and start a new one
 
         c.save()
         pdf_buffer.seek(0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fertiscan_pipeline"
-version = "0.0.10"
+version = "0.0.11"
 description = "A pipeline for the FertiScan project"
 authors = [
     { name = "Albert Bryan Ndjeutcha", email = "albert.ndjeutcha@inspection.gc.ca" }

--- a/tests/test_label.py
+++ b/tests/test_label.py
@@ -53,8 +53,8 @@ class TestDocumentStorage(unittest.TestCase):
             self.label.add_image(file.read())
 
         doc = self.label.get_document(format='pdf')
-        # save_image_to_file(doc, self.composite_document_path)
-        # self.assertTrue(os.path.exists(self.composite_document_path))
+        save_image_to_file(doc, self.composite_document_path)
+        self.assertTrue(os.path.exists(self.composite_document_path))
 
     def test_clear(self):
         with open(self.sample_image_path_1, 'rb') as file:

--- a/tests/test_label.py
+++ b/tests/test_label.py
@@ -24,35 +24,43 @@ class TestDocumentStorage(unittest.TestCase):
 
     def test_add_image_from_nonexistent_file(self):
         with self.assertRaises(FileNotFoundError):
-            self.label.add_image('fake_path')
+            with open('fake_path', 'rb') as file:
+                self.label.add_image(file.read())
 
     def test_get_document_empty(self):
         with self.assertRaises(ValueError):
             self.label.get_document()    
 
     def test_add_image(self):
-        self.label.add_image(self.sample_image_path_1)
+        with open(self.sample_image_path_1, 'rb') as file:
+            self.label.add_image(file.read())
         self.assertEqual(len(self.label.images), 1)
 
     def test_get_composite_image(self):
-        self.label.add_image(self.sample_image_path_1)
-        self.label.add_image(self.sample_image_path_2)
+        with open(self.sample_image_path_1, 'rb') as file:
+            self.label.add_image(file.read())
+        with open(self.sample_image_path_2, 'rb') as file:
+            self.label.add_image(file.read())
 
         composite_image = self.label.get_document(format='png')
         save_image_to_file(composite_image, self.composite_image_path)
         self.assertTrue(os.path.exists(self.composite_image_path))
     
     def test_get_pdf_document(self):
-        self.label.add_image(self.sample_image_path_1)
-        self.label.add_image(self.sample_image_path_2)
+        with open(self.sample_image_path_1, 'rb') as file:
+            self.label.add_image(file.read())
+        with open(self.sample_image_path_2, 'rb') as file:
+            self.label.add_image(file.read())
 
         doc = self.label.get_document(format='pdf')
-        save_image_to_file(doc, self.composite_document_path)
-        self.assertTrue(os.path.exists(self.composite_document_path))
+        # save_image_to_file(doc, self.composite_document_path)
+        # self.assertTrue(os.path.exists(self.composite_document_path))
 
     def test_clear(self):
-        self.label.add_image(self.sample_image_path_1)
-        self.label.add_image(self.sample_image_path_2)
+        with open(self.sample_image_path_1, 'rb') as file:
+            self.label.add_image(file.read())
+        with open(self.sample_image_path_2, 'rb') as file:
+            self.label.add_image(file.read())
         self.label.clear()
 
         with self.assertRaises(ValueError):

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -54,8 +54,12 @@ class TestOCR(unittest.TestCase):
     def test_composite_image_text_extraction(self):
         # Create a DocumentStorage instance and add images
         doc_storage = LabelStorage()
-        doc_storage.add_image(self.sample_image_path_1)
-        doc_storage.add_image(self.sample_image_path_2)
+        with open(self.sample_image_path_1, 'rb') as file:
+            doc_storage.add_image(file.read())
+        with open(self.sample_image_path_2, 'rb') as file:
+            doc_storage.add_image(file.read())
+        # doc_storage.add_image(self.sample_image_path_1)
+        # doc_storage.add_image(self.sample_image_path_2)
 
         # Get the composite image bytes
         composite_image_bytes = doc_storage.get_document()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -40,7 +40,9 @@ class TestPipeline(unittest.TestCase):
 
         # Initialize the objects
         self.label_storage = LabelStorage()
-        self.label_storage.add_image(self.image_path)
+        with open(self.image_path, 'rb') as file:
+            self.label_storage.add_image(file.read())
+        # self.label_storage.add_image(self.image_path)
         self.ocr = OCR(api_endpoint=self.api_endpoint_ocr, api_key=self.api_key_ocr)
         self.gpt = GPT(
             api_endpoint=self.api_endpoint_gpt,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -166,9 +166,10 @@ class TestInspectionAnnotatedFields(unittest.TestCase):
                 copied_files.append(temp_image_path)
         return copied_files
 
-    def add_images_to_storage(self, image_paths, label_storage):
+    def add_images_to_storage(self, image_paths, label_storage: LabelStorage):
         for image_path in image_paths:
-            label_storage.add_image(image_path)
+            with open(image_path, "rb") as image_file:
+                label_storage.add_image(image_file.read())
 
     def test_label_008_phone_number_inspection(self):
         label_folder = "test_data/labels/label_008"


### PR DESCRIPTION
Refactor LabelStorage to accept image bytes and update tests accordingly.

The filesystem should no longer be used.

Close #66 